### PR TITLE
Add `two-thirds` value for `flex-basis`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fa-css-utilities",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "CSS utilities for using and managing FreeAgent design properties consistently",
   "repository": {
     "type": "git",

--- a/utilities/_flex-basis.scss
+++ b/utilities/_flex-basis.scss
@@ -38,6 +38,7 @@
     (40percent, 40%),
     (50percent, 50%),
     (60percent, 60%),
+    (two-thirds, 100/3*2%),
     (75percent, 75%),
     (80percent, 80%),
     (100percent, 100%);

--- a/utilities/_flex-basis.scss
+++ b/utilities/_flex-basis.scss
@@ -32,15 +32,15 @@
   $flex-basis-values:
     (auto, auto),
     (0, 0),
-    (20percent, 20%),
-    (25percent, 25%),
-    (third, 100/3*1%),
-    (40percent, 40%),
-    (50percent, 50%),
-    (60percent, 60%),
+    (20percent,  20%),
+    (25percent,  25%),
+    (third,      100/3*1%),
+    (40percent,  40%),
+    (50percent,  50%),
+    (60percent,  60%),
     (two-thirds, 100/3*2%),
-    (75percent, 75%),
-    (80percent, 80%),
+    (75percent,  75%),
+    (80percent,  80%),
     (100percent, 100%);
 
   @each $flex-basis, $flex-basis-value in $flex-basis-values {


### PR DESCRIPTION
This adds a `two-thirds` value for the `flex-basis` property, allowing the initial width of a flexbox item to be two thirds of the width of its parent element.
