### PR TITLE
Implement scale of `border` values

### DIFF
--- a/_utility-aliases.scss
+++ b/_utility-aliases.scss
@@ -1,6 +1,7 @@
 /* Border width
    ========================================================================== */
 
+$border-width--0:        $border-width--0;
 $border-width--thin:     $border-width--1;
 $border-width--default:  $border-width--2;
 $border-width--thick:    $border-width--3;
@@ -9,6 +10,7 @@ $border-width--xx-thick: $border-width--5;
 
 /* Border width map */
 $border-width-values: (
+  0:        $border-width--0,
   thin:     $border-width--thin,
   default:  $border-width--default,
   thick:    $border-width--thick,
@@ -20,6 +22,7 @@ $border-width-values: (
 /* Border radius
    ========================================================================== */
 
+$border-radius--0:        $border-radius--0;
 $border-radius--small:    $border-radius--1;
 $border-radius--default:  $border-radius--2;
 $border-radius--large:    $border-radius--3;

--- a/_utility-values.scss
+++ b/_utility-values.scss
@@ -1,6 +1,7 @@
 /* Border
    ========================================================================== */
 
+$border-width--0: 0;
 $border-width--1: 0.5px;
 $border-width--2: 1px;
 $border-width--3: 2px;
@@ -11,6 +12,7 @@ $border-width--5: 4px;
 /* Border radius
    ========================================================================== */
 
+$border-radius--0: 0;
 $border-radius--1: 2px;
 $border-radius--2: 4px;
 $border-radius--3: 6px;

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "fa-css-utilities",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "homepage": "https://github.com/fac/fa-css-utilities",
   "authors": [
     "Robbie Manson <robbie@robbiemanson.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fa-css-utilities",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "CSS utilities for using and managing FreeAgent design properties consistently",
   "repository": {
     "type": "git",

--- a/utilities/_border.scss
+++ b/utilities/_border.scss
@@ -1,5 +1,5 @@
 /**
- * Note: scales and aliases live in _utility-values.scss 
+ * Note: scales and aliases live in _utility-values.scss
  */
 
 /* `border`
@@ -16,7 +16,7 @@
  * .MyComponent {
  *   @include fa-border(default, gray-12);
  * }
- * 
+ *
  * .retina .MyComponent {
  *   @include fa-border(thin, gray-12);
  * }
@@ -53,28 +53,26 @@
 
 @if $u-classes-border == true {
 
-  $border-values: none;
+  @each $border-width, $border-width-value in $border-width-values {
 
-  @each $border-value in $border-values {
-  
-    .u-border--#{$border-value} {
-      border: $border-value !important;
+    .u-border--#{$border-width} {
+      border: $border-width-value !important;
     }
 
-    .u-border-bottom--#{$border-value} {
-      border-bottom: $border-value !important;
-    }
-  
-    .u-border-left--#{$border-value} {
-      border-left: $border-value !important;
+    .u-border-bottom--#{$border-width} {
+      border-bottom: $border-width-value !important;
     }
 
-    .u-border-right--#{$border-value} {
-      border-right: $border-value !important;
+    .u-border-left--#{$border-width} {
+      border-left: $border-width-value !important;
     }
 
-    .u-border-top--#{$border-value} {
-      border-top: $border-value !important;
+    .u-border-right--#{$border-width} {
+      border-right: $border-width-value !important;
+    }
+
+    .u-border-top--#{$border-width} {
+      border-top: $border-width-value !important;
     }
 
   }


### PR DESCRIPTION
This branch does two things:
- Allows zero-values for `border` and `border-radius` utilities (e.g.`u-border-bottom--0`)
- Generates new utility classes for the a scale of `border` values 
