### PR TITLE
Add `default` and `dark` text colors

### DIFF
--- a/_utility-aliases.scss
+++ b/_utility-aliases.scss
@@ -92,6 +92,8 @@ $color-values: (
 $text-color-values: (
   alt:             $color--alt,
   base:            $color--base,
+  dark:            $text-color--dark,
+  default:         $text-color--default,
   fa-amber:        $color--fa-amber,
   fa-amber--dark:  $color--fa-amber--dark,
   fa-blue:         $color--fa-blue,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fa-css-utilities",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "CSS utilities for using and managing FreeAgent design properties consistently",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This adds `default` and `dark` text color aliases back to the `$color-values` map. These colors were mistakingly removed in the previous release, despite being used by FreeAgent Mobile.
