### PR TITLE
Remove `fa-` namespacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,41 +22,39 @@ Our starting point for new web projects at FreeAgent is [FA Origin](https://gith
 
 **Global values and aliases**. Global utility values are defined in [`_utility-values`](https://github.com/fac/fa-css-utilities/blob/master/_utility-values.scss). Utilities `font-size`, `line-height`, `padding`, `margin`, etc have scales of values, as well as aliases. All aliases live in [`_utility-aliases.scss`](https://github.com/fac/fa-css-utilities/blob/master/_utility-aliases.scss). Aliases provide a finite scale (`x-small`, `default`, `xx-large`, etc) to make authoring easier and more meaningful.
 
-**Local aliases**. You can assign local, project-specific aliases to global values by adding rules to [`_project-aliases`](https://github.com/fac/fa-css-utilities/blob/master/_project-aliases.scss). This way you aren’t continually declaring something like `@include fa-line-height(x-loose)` for your project’s default `line-height`. You can just assign `x-loose` to `default` for your project.
-
-**Meaningful namespacing**. Mixins for any FreeAgent-specific properties are prepended with `fa-`. Simple rule: if we have a custom value for a property (i.e. a value that isn't part of the CSS spec), we have a custom namespace (and associated mixins).
+**Local aliases**. You can assign local, project-specific aliases to global values by adding rules to [`_project-aliases`](https://github.com/fac/fa-css-utilities/blob/master/_project-aliases.scss). This way you aren’t continually declaring something like `@include line-height(x-loose)` for your project’s default `line-height`. You can just assign `x-loose` to `default` for your project.
 
 **Turning utility classes on/off**. Utility _classes_ mirror the behaviour of our mixins but can be applied to HTML elements directly. Rendering all of them naturally adds a lot of weight a `.css` file, so they can be individually turned on/off in [`_utility-settings.scss`](https://github.com/fac/fa-origin/blob/master/assets/scss/_utility-settings.scss). Utility classes have `!important` because utilities exist to do _one thing no matter what_.
 
-**Optional `!important`**. `!important` can be added to any mixin declaration, e.g.: `@include fa-padding(large, !important);`. This is especially useful for refactoring; `!important` allows us a way to turn existing UI patterns that rely on the cascade into completely self-contained components — _without_ breaking lots of stuff. Once a component has been created and rolled out, any `!important` arguments can just be removed.
+**Optional `!important`**. `!important` can be added to any mixin declaration, e.g.: `@include padding(large, !important);`. This is especially useful for refactoring; `!important` allows us a way to turn existing UI patterns that rely on the cascade into completely self-contained components — _without_ breaking lots of stuff. Once a component has been created and rolled out, any `!important` arguments can just be removed.
 
 ### Examples
 
-Most utilities can be applied two ways: directly to HTML elements as classes, or as mixins in a `.scss` file. Utilities can be added to any element, multiple utilities can be used together, and utilities can be used alongside components.
+Most utilities can be applied two ways: using mixins in a `.scss` file, or directly to HTML elements as utility classes. Using mixins is preferred as you get all of the utility functionality without any extra weight being added to the output CSS file, and it encourages the idea of a component-based system.
 
-#### Using mixins in SASS
+#### Using mixins in `.scss` files
 
 ```scss
 .MyComponent {
-  @include fa-background-color(gray-13);
-  @include fa-font-family(default);
-  @include fa-font-size(large);
-  @include fa-line-height(tight);
-  @include fa-text-color(fa-blue);
+  @include background-color(gray-13);
+  @include font-family(default);
+  @include font-size(large);
+  @include line-height(tight);
+  @include text-color(fa-blue);
 }
 
 .MyOtherComponent {
-  @include fa-margin-top(large);
   @include flexbox(flex);
   @include flex-direction(row-reverse);
   @include flex-justify-content(center);
   @include flex-grow(2);
   @include flex-shrink(0);
+  @include margin-top(large);
 }
 ```
 
 #### Using utility classes in HTML
-Utility classes are useful for prototyping ideas, but treat them as temporary (remember they apply `!important`). Components should handle their own states and variants, so there should be relatively few utility classes being used in production.
+Utility classes are useful for prototyping ideas, but use them with care and treat them as stop-gaps (remember they apply `!important`). Components should handle their own states and variants, so there should be relatively few utility classes being used in production.
 
 **You might start with this&hellip;**
 
@@ -81,21 +79,21 @@ Utility classes are useful for prototyping ideas, but treat them as temporary (r
   margin: 0;
   padding: 0;
   text-align: center;
-  @include fa-border-radius(default);
-  @include fa-border(thin, solid, fa-blue);
-  @include fa-line-height(tight);
+  @include border-radius(default);
+  @include border(thin, solid, fa-blue);
   @include flexbox(flex);
   @include flex-align-items(stretch);
   @include flex-direction(row);
+  @include line-height(tight);
 
 .SegmentedControl-segment {
   background: none;
   display: inline-block;
   margin: 0;
-  @include fa-border-right(thin, solid, fa-blue);
-  @include fa-padding(x-small, small)
-  @include fa-text-color(x-light);
+  @include border-right(thin, solid, fa-blue);
   @include flex-grow(1);
+  @include padding(x-small, small)
+  @include text-color(x-light);
   @include text-truncate;
 }
 ```

--- a/_utility-aliases.scss
+++ b/_utility-aliases.scss
@@ -5,7 +5,7 @@
  *
  * The maps and other logic used to generate the `.u-property` classes are
  * contained in /utilities. In almost all cases each property is contained in
- * it’s own partial.  
+ * it’s own partial.
  */
 
 /* Border width

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "fa-css-utilities",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "homepage": "https://github.com/fac/fa-css-utilities",
   "authors": [
     "Robbie Manson <robbie@robbiemanson.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fa-css-utilities",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "CSS utilities for using and managing FreeAgent design properties consistently",
   "repository": {
     "type": "git",

--- a/utilities/_animation.scss
+++ b/utilities/_animation.scss
@@ -14,7 +14,7 @@ $transition-length-default: 450ms;
  * Use to define an animation. If `$length` and `$transition` are not defined,
  * the global defaults (`$transition-length-default` and `$transition-property-default`
  * respectively will be used)
- * 
+ *
  * Example usage:
  * `@include animation(fadeInOut, 1s, ease-out, infinite);`
  * `@include animation(ease-out, !important);`
@@ -55,6 +55,6 @@ $transition-length-default: 450ms;
     @content
   };
   @keyframes #{$name} {
-    @content 
+    @content
   };
 }

--- a/utilities/_background.scss
+++ b/utilities/_background.scss
@@ -8,11 +8,11 @@
     none;
 
   @each $background-value in $background-values {
-  
+
     .u-background--#{$background-value} {
       background: $background-value !important;
     }
-  
+
   }
 
 }
@@ -23,12 +23,12 @@
 
 /**
  * Example usage:
- * `@include fa-background-color(gray-12);`
- * `@include fa-background-color(fa-blue);`
- * `@include fa-background-color(gray-16, !important);`
+ * `@include background-color(gray-12);`
+ * `@include background-color(fa-blue);`
+ * `@include background-color(gray-16, !important);`
  */
 
-@mixin fa-background-color($value, $important: null) {
+@mixin background-color($value, $important: null) {
   background-color: map-get($color-values, $value) $important;
 }
 
@@ -36,11 +36,11 @@
 @if $u-classes-background == true {
 
   @each $color, $color-value in $color-values {
-  
+
     .u-background-color--#{$color} {
       background-color: $color-value !important;
     }
-  
+
   }
 
   $background-color-values:
@@ -48,11 +48,11 @@
     transparent;
 
   @each $background-color-value in $background-color-values {
-  
+
     .u-background-color--#{$background-color-value} {
       background-color: $background-color-value !important;
     }
-  
+
     .u-background-color--#{$background-color-value}--active:active {
       background-color: $background-color-value !important;
     }
@@ -74,11 +74,11 @@
     none;
 
   @each $background-image-value in $background-image-values {
-  
+
     .u-background-image--#{$background-image-value} {
       background-image: $background-image-value !important;
     }
-  
+
   }
 
 }
@@ -101,11 +101,11 @@
     (right-top, right top);
 
   @each $background-position, $background-position-value in $background-position-values {
-  
+
     .u-background-position--#{$background-position} {
       background-position: $background-position-value !important;
     }
-  
+
   }
 
 }
@@ -121,11 +121,11 @@
     contain;
 
   @each $background-size-value in $background-size-values {
-  
+
     .u-background-size--#{$background-size-value} {
       background-size: $background-size-value !important;
     }
-  
+
   }
 
 }

--- a/utilities/_border-radius.scss
+++ b/utilities/_border-radius.scss
@@ -3,8 +3,8 @@
 
 /**
  * Example usage:
- * `@include fa-border-radius(large);`
- * `@include fa-border-radius(small, !important);`
+ * `@include border-radius(large);`
+ * `@include border-radius(small, !important);`
  */
 
 
@@ -24,7 +24,7 @@ $border-radius-values: (
 /* `border-radius`
    ========================================================================== */
 
-@mixin fa-border-radius($value, $important: null) {
+@mixin border-radius($value, $important: null) {
   border-radius: map-get($border-radius-values, $value) $important;
 }
 
@@ -44,7 +44,7 @@ $border-radius-values: (
 /* `border-bottom-left-radius`
    ========================================================================== */
 
-@mixin fa-border-radius-bottom-left($value, $important: null) {
+@mixin border-radius-bottom-left($value, $important: null) {
   border-bottom-left-radius: map-get($border-radius-values, $value) $important;
 }
 
@@ -64,7 +64,7 @@ $border-radius-values: (
 /* `border-bottom-right-radius`
    ========================================================================== */
 
-@mixin fa-border-radius-bottom-right($value, $important: null) {
+@mixin border-radius-bottom-right($value, $important: null) {
   border-bottom-right-radius: map-get($border-radius-values, $value) $important;
 }
 
@@ -84,7 +84,7 @@ $border-radius-values: (
 /* `border-top-left-radius`
    ========================================================================== */
 
-@mixin fa-border-radius-top-left($value, $important: null) {
+@mixin border-radius-top-left($value, $important: null) {
   border-top-left-radius: map-get($border-radius-values, $value) $important;
 }
 
@@ -104,7 +104,7 @@ $border-radius-values: (
 /* `border-top-right-radius`
    ========================================================================== */
 
-@mixin fa-border-radius-top-right($value, $important: null) {
+@mixin border-radius-top-right($value, $important: null) {
   border-top-right-radius: map-get($border-radius-values, $value) $important;
 }
 

--- a/utilities/_border.scss
+++ b/utilities/_border.scss
@@ -7,18 +7,18 @@
 
 /**
  * Example usage:
- * `@include fa-border(default, gray-13);`
- * `@include fa-border-bottom(thick, fa-blue, !important);`
+ * `@include border(default, gray-13);`
+ * `@include border-bottom(thick, fa-blue, !important);`
  *
  * Retina (0.5px) border:
  *
  * ```
  * .MyComponent {
- *   @include fa-border(default, gray-12);
+ *   @include border(default, gray-12);
  * }
  *
  * .retina .MyComponent {
- *   @include fa-border(thin, gray-12);
+ *   @include border(thin, gray-12);
  * }
  * ```
  */
@@ -27,23 +27,23 @@
 /* Mixin
    ========================================================================== */
 
-@mixin fa-border($border-width-value, $border-color-value, $important: null) {
+@mixin border($border-width-value, $border-color-value, $important: null) {
   border: map-get($border-width-values, $border-width-value) solid map-get($color-values, $border-color-value) $important;
 }
 
-@mixin fa-border-bottom($border-width-value, $border-color-value, $important: null) {
+@mixin border-bottom($border-width-value, $border-color-value, $important: null) {
   border-bottom: map-get($border-width-values, $border-width-value) solid map-get($color-values, $border-color-value) $important;
 }
 
-@mixin fa-border-left($border-width-value, $border-color-value, $important: null) {
+@mixin border-left($border-width-value, $border-color-value, $important: null) {
   border-left: map-get($border-width-values, $border-width-value) solid map-get($color-values, $border-color-value) $important;
 }
 
-@mixin fa-border-right($border-width-value, $border-color-value, $important: null) {
+@mixin border-right($border-width-value, $border-color-value, $important: null) {
   border-right: map-get($border-width-values, $border-width-value) solid map-get($color-values, $border-color-value) $important;
 }
 
-@mixin fa-border-top($border-width-value, $border-color-value, $important: null) {
+@mixin border-top($border-width-value, $border-color-value, $important: null) {
   border-top: map-get($border-width-values, $border-width-value) solid map-get($color-values, $border-color-value) $important;
 }
 

--- a/utilities/_flex-basis.scss
+++ b/utilities/_flex-basis.scss
@@ -44,11 +44,11 @@
     (100percent, 100%);
 
   @each $flex-basis, $flex-basis-value in $flex-basis-values {
-  
+
     .u-flex-basis--#{$flex-basis} {
       @include flex-basis(#{$flex-basis-value}, !important);
     }
-  
+
   }
 
 }

--- a/utilities/_font-family.scss
+++ b/utilities/_font-family.scss
@@ -24,12 +24,12 @@ $font-family-values: (
 
 /**
  * Example usage:
- * `@include fa-font-family(default);`
- * `@include fa-font-family(editorial);`
- * `@include fa-font-family(legacy, !important);`
+ * `@include font-family(default);`
+ * `@include font-family(editorial);`
+ * `@include font-family(legacy, !important);`
  */
 
-@mixin fa-font-family($value, $important: null) {
+@mixin font-family($value, $important: null) {
   font-family: map-get($font-family-values, $value) $important;
 }
 

--- a/utilities/_font-size.scss
+++ b/utilities/_font-size.scss
@@ -1,5 +1,5 @@
 /**
- * Note: scales, aliases and maps live in _utility-values.scss 
+ * Note: scales, aliases and maps live in _utility-values.scss
  */
 
 
@@ -39,12 +39,12 @@ $font-size-values: (
 
 /**
  * Example usage:
- * `@include fa-font-size(small);`
- * `@include fa-font-size(x-large);`
- * `@include fa-font-size(17, !important);`
+ * `@include font-size(small);`
+ * `@include font-size(x-large);`
+ * `@include font-size(17, !important);`
  */
 
-@mixin fa-font-size($value, $important: null) {
+@mixin font-size($value, $important: null) {
   font-size: map-get($font-size-values, $value) $important;
 }
 

--- a/utilities/_font-weight.scss
+++ b/utilities/_font-weight.scss
@@ -33,12 +33,12 @@ $font-weight-values: (
 
 /**
  * Example usage:
- * `@include fa-font-weight(thin);`
- * `@include fa-font-weight(bold);`
- * `@include fa-font-weight(9, !important);`
+ * `@include font-weight(thin);`
+ * `@include font-weight(bold);`
+ * `@include font-weight(9, !important);`
  */
 
-@mixin fa-font-weight($value, $important: null) {
+@mixin font-weight($value, $important: null) {
   font-weight: map-get($font-weight-values, $value) $important;
 }
 

--- a/utilities/_line-height.scss
+++ b/utilities/_line-height.scss
@@ -32,12 +32,12 @@ $line-height-values: (
 
 /**
  * Example usage:
- * `@include fa-line-height(tight);`
- * `@include fa-line-height(x-loose);`
- * `@include fa-line-height(9, !important);`
+ * `@include line-height(tight);`
+ * `@include line-height(x-loose);`
+ * `@include line-height(9, !important);`
  */
 
-@mixin fa-line-height($value, $important: null) {
+@mixin line-height($value, $important: null) {
   line-height: map-get($line-height-values, $value) $important;
 }
 

--- a/utilities/_list-item-spacing.scss
+++ b/utilities/_list-item-spacing.scss
@@ -8,12 +8,12 @@
 
 /**
  * Example usage:
- * `@include fa-list-item-spacing(tight);`
- * `@include fa-list-item-spacing(default);`
- * `@include fa-list-item-spacing(x-loose, !important);`
+ * `@include list-item-spacing(tight);`
+ * `@include list-item-spacing(default);`
+ * `@include list-item-spacing(x-loose, !important);`
  */
 
-@mixin fa-list-item-spacing($value, $important: null) {
+@mixin list-item-spacing($value, $important: null) {
   margin-bottom: map-get($list-item-spacing-values, $value) $important;
 }
 

--- a/utilities/_margin.scss
+++ b/utilities/_margin.scss
@@ -1,5 +1,5 @@
 /**
- * Note: scales, aliases and maps live in _utility-values.scss 
+ * Note: scales, aliases and maps live in _utility-values.scss
  */
 
 
@@ -8,28 +8,28 @@
 
 /**
  * Example usage:
- * `@include fa-margin(default);`
- * `@include fa-margin-left(large);`
- * `@include fa-margin-bottom(xx-large, !important);`
+ * `@include margin(default);`
+ * `@include margin-left(large);`
+ * `@include margin-bottom(xx-large, !important);`
  */
 
-@mixin fa-margin($value, $important: null) {
+@mixin margin($value, $important: null) {
   margin: map-get($spacing-values, $value) $important;
 }
 
-@mixin fa-margin-bottom($value, $important: null) {
+@mixin margin-bottom($value, $important: null) {
   margin-bottom: map-get($spacing-values, $value) $important;
 }
 
-@mixin fa-margin-left($value, $important: null) {
+@mixin margin-left($value, $important: null) {
   margin-left: map-get($spacing-values, $value) $important;
 }
 
-@mixin fa-margin-right($value, $important: null) {
+@mixin margin-right($value, $important: null) {
   margin-right: map-get($spacing-values, $value) $important;
 }
 
-@mixin fa-margin-top($value, $important: null) {
+@mixin margin-top($value, $important: null) {
   margin-top: map-get($spacing-values, $value) $important;
 }
 
@@ -40,7 +40,7 @@
 @if $u-classes-margin == true {
 
   @each $spacing-size, $spacing-value in $spacing-values {
-  
+
     .u-margin--#{$spacing-size} {
       margin: $spacing-value !important;
     }
@@ -56,7 +56,7 @@
     .u-margin-top--#{$spacing-size} {
       margin-top: $spacing-value !important;
     }
-  
+
   }
 
 }

--- a/utilities/_padding.scss
+++ b/utilities/_padding.scss
@@ -1,5 +1,5 @@
 /**
- * Note: scales, aliases and maps live in _utility-values.scss 
+ * Note: scales, aliases and maps live in _utility-values.scss
  */
 
 
@@ -8,28 +8,28 @@
 
 /**
  * Example usage:
- * `@include fa-padding(default);`
- * `@include fa-padding-left(large);`
- * `@include fa-padding-bottom(xx-large, !important);`
+ * `@include padding(default);`
+ * `@include padding-left(large);`
+ * `@include padding-bottom(xx-large, !important);`
  */
 
-@mixin fa-padding($value, $important: null) {
+@mixin padding($value, $important: null) {
   padding: map-get($spacing-values, $value) $important;
 }
 
-@mixin fa-padding-bottom($value, $important: null) {
+@mixin padding-bottom($value, $important: null) {
   padding-bottom: map-get($spacing-values, $value) $important;
 }
 
-@mixin fa-padding-left($value, $important: null) {
+@mixin padding-left($value, $important: null) {
   padding-left: map-get($spacing-values, $value) $important;
 }
 
-@mixin fa-padding-right($value, $important: null) {
+@mixin padding-right($value, $important: null) {
   padding-right: map-get($spacing-values, $value) $important;
 }
 
-@mixin fa-padding-top($value, $important: null) {
+@mixin padding-top($value, $important: null) {
   padding-top: map-get($spacing-values, $value) $important;
 }
 
@@ -40,7 +40,7 @@
 @if $u-classes-padding == true {
 
   @each $spacing-size, $spacing-value in $spacing-values {
-  
+
     .u-padding--#{$spacing-size} {
       padding: $spacing-value !important;
     }
@@ -56,7 +56,7 @@
     .u-padding-top--#{$spacing-size} {
       padding-top: $spacing-value !important;
     }
-  
+
   }
 
 }

--- a/utilities/_text-color.scss
+++ b/utilities/_text-color.scss
@@ -8,12 +8,12 @@
 
 /**
  * Example usage:
- * `@include fa-text-color(default);`
- * `@include fa-text-color(light);`
- * `@include fa-text-color(fa-blue, !important);`
+ * `@include text-color(default);`
+ * `@include text-color(light);`
+ * `@include text-color(fa-blue, !important);`
  */
 
-@mixin fa-text-color($value, $important: null) {
+@mixin text-color($value, $important: null) {
   color: map-get($text-color-values, $value) $important;
 }
 


### PR DESCRIPTION
This removes all instances of `fa-` namespacing from the whole utility codebase, except our colours. Removing them from colours too may be explored in another branch.

The namespacing was originally introduced to clarify when certain properties had custom FreeAgent-centric values. But as more designers and engineers have actually used the utilities, that distinction has proved unnecessary. If removing them means typing less characters _and_ keeping code clear, we should do it. Removing them also brings the naming conventions of mixins and utility classes closer together.
### Example

**Before**

``` scss
.MyComponent {
  @include fa-background-color(gray-13);
  @include fa-font-family(default);
  @include fa-font-size(large);
  @include fa-line-height(tight);
  @include fa-text-color(fa-blue);
}
```

**After**

``` scss
.MyComponent {
  @include background-color(gray-13);
  @include font-family(default);
  @include font-size(large);
  @include line-height(tight);
  @include text-color(fa-blue);
}
```
