### PR TITLE
Change spacing units from `em` to `rem`

### DIFF
--- a/_utility-values.scss
+++ b/_utility-values.scss
@@ -143,23 +143,23 @@ $line-height--11: 155%;
    ========================================================================== */
 
 $spacing--0:  0;
-$spacing--1:  0.15em;
-$spacing--2:  0.25em;
-$spacing--3:  0.5em;
-$spacing--4:  0.75em;
-$spacing--5:  1em;
-$spacing--6:  1.25em;
-$spacing--7:  1.5em;
-$spacing--8:  1.75em;
-$spacing--9:  2em;
-$spacing--10: 2.25em;
-$spacing--11: 2.5em;
-$spacing--12: 2.75em;
-$spacing--13: 3em;
-$spacing--14: 3.5em;
-$spacing--15: 4em;
-$spacing--16: 4.5em;
-$spacing--17: 5em;
+$spacing--1:  0.15rem;
+$spacing--2:  0.25rem;
+$spacing--3:  0.5rem;
+$spacing--4:  0.75rem;
+$spacing--5:  1rem;
+$spacing--6:  1.25rem;
+$spacing--7:  1.5rem;
+$spacing--8:  1.75rem;
+$spacing--9:  2rem;
+$spacing--10: 2.25rem;
+$spacing--11: 2.5rem;
+$spacing--12: 2.75rem;
+$spacing--13: 3rem;
+$spacing--14: 3.5rem;
+$spacing--15: 4rem;
+$spacing--16: 4.5rem;
+$spacing--17: 5rem;
 
 
 /* `z-index`

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "fa-css-utilities",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "homepage": "https://github.com/fac/fa-css-utilities",
   "authors": [
     "Robbie Manson <robbie@robbiemanson.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fa-css-utilities",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "CSS utilities for using and managing FreeAgent design properties consistently",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This switches the spacing units we use for `margin` and `padding` utilities from `em`s to `rem`s.

`em` units are useful when scale should be derived from the `font-size` of an individual element. But by default, scale should be derived from a single global unit: the `font-size` of `html`. This is what `rem`s do. Now our margin and padding values will be consistent to a single scale, regardless of their dimensions or markup structure.

If in future we want to use `em` (an example may be when we implement a `Heading` component, where bottom margins should be linked to the heading sizes), we can do so.
