### PR TITLE
Allow shorthand margin padding values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fa-css-utilities",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "CSS utilities for using and managing FreeAgent design properties consistently",
   "repository": {
     "type": "git",

--- a/utilities/_margin.scss
+++ b/utilities/_margin.scss
@@ -7,21 +7,21 @@
    ========================================================================== */
 
 /**
-* Example usage:
-* `@include margin(default);`
-* `@include margin(default large);`
-* `@include margin(x-large small, !important);`
-* `@include margin-left(large);`
-* `@include margin-bottom(xx-large, !important);`
-*/
+ * Example usage:
+ * `@include margin(default);`
+ * `@include margin(default large);`
+ * `@include margin(x-large small, !important);`
+ * `@include margin-left(large);`
+ * `@include margin-bottom(xx-large, !important);`
+ */
 
 /**
-* This mixin allows us to use shorthand values for the `margin` property.
-*
-* The mixin runs through our spacing values, given in the first argument, then
-* creates another list of the mappings of those spacing values, which it then
-* feeds to the `margin` property.
-*/
+ * This mixin allows us to use shorthand values for the `margin` property.
+ *
+ * The mixin runs through our spacing values, given in the first argument, then
+ * creates another list of the mappings of those spacing values, which it then
+ * feeds to the `margin` property.
+ */
 
 @mixin margin($values, $important: null) {
   $valueList: ();

--- a/utilities/_margin.scss
+++ b/utilities/_margin.scss
@@ -7,14 +7,31 @@
    ========================================================================== */
 
 /**
- * Example usage:
- * `@include margin(default);`
- * `@include margin-left(large);`
- * `@include margin-bottom(xx-large, !important);`
- */
+* Example usage:
+* `@include margin(default);`
+* `@include margin(default large);`
+* `@include margin(x-large small, !important);`
+* `@include margin-left(large);`
+* `@include margin-bottom(xx-large, !important);`
+*/
 
-@mixin margin($value, $important: null) {
-  margin: map-get($spacing-values, $value) $important;
+/**
+* This mixin allows us to use shorthand values for the `margin` property.
+*
+* The mixin runs through our spacing values, given in the first argument, then
+* creates another list of the mappings of those spacing values, which it then
+* feeds to the `margin` property.
+*/
+
+@mixin margin($values, $important: null) {
+  $valueList: ();
+
+  @for $i from 1 through length($values) {
+    $value: map-get($spacing-values, nth($values, $i));
+    $valueList: append($valueList, $value, space);
+  }
+
+  margin: $valueList $important;
 }
 
 @mixin margin-bottom($value, $important: null) {

--- a/utilities/_margin.scss
+++ b/utilities/_margin.scss
@@ -10,6 +10,7 @@
  * Example usage:
  * `@include margin(default);`
  * `@include margin(default large);`
+ * `@include padding(default large x-large xx-small);`
  * `@include margin(x-large small, !important);`
  * `@include margin-left(large);`
  * `@include margin-bottom(xx-large, !important);`

--- a/utilities/_padding.scss
+++ b/utilities/_padding.scss
@@ -9,12 +9,29 @@
 /**
  * Example usage:
  * `@include padding(default);`
+ * `@include padding(default large);`
+ * `@include padding(x-large small, !important);`
  * `@include padding-left(large);`
  * `@include padding-bottom(xx-large, !important);`
  */
 
-@mixin padding($value, $important: null) {
-  padding: map-get($spacing-values, $value) $important;
+/**
+ * This mixin allows us to use shorthand values for the `padding` property.
+ *
+ * The mixin runs through our spacing values, given in the first argument, then
+ * creates another list of the mappings of those spacing values, which it then
+ * feeds to the `padding` property.
+ */
+
+@mixin padding($values, $important: null) {
+  $valueList: ();
+
+  @for $i from 1 through length($values) {
+    $value: map-get($spacing-values, nth($values, $i));
+    $valueList: append($valueList, $value, space);
+  }
+
+  padding: $valueList $important;
 }
 
 @mixin padding-bottom($value, $important: null) {

--- a/utilities/_padding.scss
+++ b/utilities/_padding.scss
@@ -10,6 +10,7 @@
  * Example usage:
  * `@include padding(default);`
  * `@include padding(default large);`
+ * `@include padding(default large x-large xx-small);`
  * `@include padding(x-large small, !important);`
  * `@include padding-left(large);`
  * `@include padding-bottom(xx-large, !important);`


### PR DESCRIPTION
This allows shorthand values for `margin` and `padding` properties to be used. Using shorthand is completely optional, so there are no breaking changes here.

How it works: a mixin runs through our spacing values list, then creates another list of the mappings of those spacing values, which it then feeds to the `margin` and `padding` properties.

After being merged to master, a new release will created, then Origin will be updated with this new work in a new release of its own. 
