### PR TITLE
Add media query utility and range of breakpoints

### DIFF
--- a/_utilities.scss
+++ b/_utilities.scss
@@ -57,6 +57,7 @@
 @import "utilities/_list-item-spacing";
 @import "utilities/_list-style";
 @import "utilities/_margin";
+@import "utilities/_media-query";
 @import "utilities/_opacity";
 @import "utilities/_overflow";
 @import "utilities/_padding";

--- a/_utility-values.scss
+++ b/_utility-values.scss
@@ -26,6 +26,16 @@ $border-radius--4: 8px;
 $border-radius--5: 10px;
 
 
+/* Breakpoints
+   ========================================================================== */
+
+$small-breakpoint:    0;
+$medium-breakpoint:   44rem;
+$large-breakpoint:    60rem;
+$x-large-breakpoint:  76rem;
+$xx-large-breakpoint: 92rem;
+
+
 /* Colors
    ========================================================================== */
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "fa-css-utilities",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "homepage": "https://github.com/fac/fa-css-utilities",
   "authors": [
     "Robbie Manson <robbie@robbiemanson.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fa-css-utilities",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "CSS utilities for using and managing FreeAgent design properties consistently",
   "repository": {
     "type": "git",

--- a/utilities/_media-query.scss
+++ b/utilities/_media-query.scss
@@ -1,0 +1,39 @@
+/* Media queries
+   ========================================================================== */
+
+/**
+ * This media query mixin gives us a common way of triggering CSS changes based
+ * on `min-width` breakpoints.
+ *
+ * Our global breakpoints are defined in our utility values:
+ * https://github.com/fac/fa-css-utilities/blob/master/_utility-values.scss
+ */
+
+/* `false` will disable media queries */
+$supported: true !default; //
+
+@mixin break($point, $support: $supported) {
+  @if $support == true {
+
+    /* Output mixin content inside a media query */
+    @if $point == sm {
+      @media (min-width: $small-breakpoint) { @content; }
+    }
+    @else if $point == md {
+      @media (min-width: $medium-breakpoint) { @content; }
+    }
+    @else if $point == lg {
+      @media (min-width: $large-breakpoint) { @content; }
+    }
+    @else if $point == x-lg {
+      @media (min-width: $x-large-breakpoint) { @content; }
+    }
+    @else if $point == xx-lg {
+      @media (min-width: $xx-large-breakpoint) { @content; }
+    }
+  } @else {
+
+    /* Output content inside the mixin, without a media query */
+    @content;
+  }
+}


### PR DESCRIPTION
This introduces a media query utility mixin and a range of small, medium, large, x-large, and xx-large breakpoints for using with it.

These breakpoints may change over time, but for the purposes of introducing Grid and Block Grid components in Origin these are working well.
